### PR TITLE
fix compile warning for va_start and va_end (missing semicolon in do …

### DIFF
--- a/include/generic/stdarg.h
+++ b/include/generic/stdarg.h
@@ -34,8 +34,8 @@ SOFTWARE.
 
 typedef volatile unsigned va_list;
 
-#define va_start(ap, parmN) do { ap = 0 } while( 0 )
+#define va_start(ap, parmN) do { ap = 0; } while( 0 )
 #define va_arg(ap,  type) ((type)ap++)
-#define va_end(ap) do { ap = 0 } while( 0 )
+#define va_end(ap) do { ap = 0; } while( 0 )
 
 #endif


### PR DESCRIPTION
…block